### PR TITLE
check for null in matching

### DIFF
--- a/babel-build-helpers.js
+++ b/babel-build-helpers.js
@@ -15,7 +15,9 @@ if (!fs.existsSync(directory)) {
 
 helpers.forEach(function (helper) {
   if (!helper) return
-  var name = helper.match(/(^[^ ]*) = /)[1]
+  var matches = helper.match(/(^[^ ]*) = /)
+  if (!matches) return
+  var name = matches[1]
   var body = 'module.exports = ' + helper.split(/^[^ ]* = /)[1]
   fs.writeFileSync(path.join(directory, name + '.js'), body)
 })


### PR DESCRIPTION
I like your build scripts, so in a project of mine I was trying to use this one, and it was giving me an error on installing it as an npm package. When I ran `npm install jessetane/build-js` it would throw a null reference exception, and this patch seemed to have fixed it.

Also, your readme specifies `npm install jessetane/build-js#1.0.0` is that the one I should be using rather than your latest?